### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Hello everyone,
 
 ![alt tag](http://i.imgur.com/wxAH9kO.jpg)
 
-###About
+### About
 
 There's multiple things that makes DAws better than every Web Shell out there:
 
@@ -19,10 +19,10 @@ There's multiple things that makes DAws better than every Web Shell out there:
 1. Open Source.
 1. and much more (check the source for more information; everything is well commented)
 
-###Credits:
+### Credits:
 1. [dotcppfile](https://twitter.com/dotcppfile)
 1. Aces who helped me code the old version of DAws
 1. Vedu for checking and reporting bugs.
 
-###Blog:
+### Blog:
 1. https://dotcppfile.wordpress.com/


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
